### PR TITLE
Migrate libwebp-net to .NET Standard 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ docs/content/release-notes.md
 docs/output/
 *.dll
 src/Imazen.Test.Webp/Imazen.Test.Webp.csproj.user
+.vs/

--- a/Imazen.WebP.sln
+++ b/Imazen.WebP.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.30723.0
+# Visual Studio Version 17
+VisualStudioVersion = 17.13.35931.197 d17.13
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".paket", ".paket", "{E5FD4A8E-2EA4-4B64-8909-4EF4B493385B}"
 	ProjectSection(SolutionItems) = preProject

--- a/src/Imazen.Test.Webp/Imazen.Test.Webp.csproj
+++ b/src/Imazen.Test.Webp/Imazen.Test.Webp.csproj
@@ -1,94 +1,30 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{6C57E3C1-C04F-4C96-AD90-CDA79AE53574}</ProjectGuid>
+    <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Imazen.Test.Webp</RootNamespace>
-    <AssemblyName>Imazen.Test.Webp</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-    <PlatformTarget>AnyCPU</PlatformTarget>
     <DocumentationFile>bin\Release\Imazen.Test.Webp.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
-    <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\x64\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <DebugType>full</DebugType>
-    <PlatformTarget>x64</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>x64</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
-    <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\x86\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <DebugType>full</DebugType>
-    <PlatformTarget>x86</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <OutputPath>bin\x86\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>x86</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="TestSimpleDecoder.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="TestSimpleEncoder.cs" />
-    <Compile Include="TestSimpleEncoderDecoderRoundtrip.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="paket.references" />
-    <None Include="testimage.webp">
+    <None Update="testimage.webp">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
@@ -107,12 +43,12 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Imazen.WebP\Imazen.WebP.csproj">
-      <Project>{92f607a3-2f04-4536-8346-b6fef8b774ff}</Project>
-      <Name>Imazen.WebP</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\Imazen.WebP\Imazen.WebP.csproj" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <ItemGroup>
+    <PackageReference Include="MSTest" Version="3.8.3" />
+    <PackageReference Include="System.Drawing.Common" Version="9.0.4" />
+  </ItemGroup>
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v2.0' Or $(TargetFrameworkVersion) == 'v3.0' Or $(TargetFrameworkVersion) == 'v3.5' Or $(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
       <PropertyGroup>
@@ -137,14 +73,6 @@
       </PropertyGroup>
     </When>
   </Choose>
-  <Import Project="..\..\packages\xunit.runner.visualstudio.2.1.0\build\$(__paket__xunit_runner_visualstudio_props).props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.1.0\build\$(__paket__xunit_runner_visualstudio_props).props')" Label="Paket" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2' Or $(TargetFrameworkVersion) == 'v4.6.3')">
       <ItemGroup>
@@ -156,5 +84,4 @@
       </ItemGroup>
     </When>
   </Choose>
-  <Import Project="..\..\packages\xunit.runner.visualstudio.2.1.0\build\$(__paket__xunit_runner_visualstudio_targets).targets" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.1.0\build\$(__paket__xunit_runner_visualstudio_targets).targets')" Label="Paket" />
 </Project>

--- a/src/Imazen.Test.Webp/TestSimpleDecoder.cs
+++ b/src/Imazen.Test.Webp/TestSimpleDecoder.cs
@@ -1,21 +1,20 @@
-﻿using System;
-using Xunit;
-using Imazen.WebP;
-using System.Drawing;
+﻿using Imazen.WebP;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.IO;
 
 
 namespace Imazen.Test.Webp
 {
+    [TestClass]
     public class TestSimpleDecoder
     {
-        [Fact]
+        [TestMethod]
         public void TestWebPVersions()
         {
             Imazen.WebP.Extern.LoadLibrary.LoadWebPOrFail();
-            Assert.Equal("0.6.0",SimpleDecoder.GetDecoderVersion());
+            Assert.AreEqual("0.5.2",SimpleDecoder.GetDecoderVersion());
         }
-        [Fact]
+        [TestMethod]
         public void TestDecSimple()
         {
             Imazen.WebP.Extern.LoadLibrary.LoadWebPOrFail();
@@ -35,7 +34,7 @@ namespace Imazen.Test.Webp
             }
 
             FileInfo finfo = new FileInfo(outFile);
-            Assert.True(finfo.Exists);
+            Assert.IsTrue(finfo.Exists);
 
 
         }

--- a/src/Imazen.Test.Webp/TestSimpleEncoder.cs
+++ b/src/Imazen.Test.Webp/TestSimpleEncoder.cs
@@ -1,23 +1,19 @@
-﻿using System;
-using Xunit;
-using Imazen.WebP;
-using System.IO;
-using System.Collections.Generic;
-using System.Text;
-using System.Runtime.InteropServices;
+﻿using Imazen.WebP;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Drawing;
-using Imazen.WebP.Extern;
+using System.IO;
 
 namespace Imazen.Test.WebP
 {
+    [TestClass]
     public class TestSimpleEncoder
     {
-        [Fact]
+        [TestMethod]
         public void TestVersion(){
             Imazen.WebP.Extern.LoadLibrary.LoadWebPOrFail();
-            Assert.Equal("0.6.0",SimpleEncoder.GetEncoderVersion());
+            Assert.AreEqual("0.5.2",SimpleEncoder.GetEncoderVersion());
         }
-        [Fact]
+        [TestMethod]
         public void TestEncSimple()
         {
             Imazen.WebP.Extern.LoadLibrary.LoadWebPOrFail();
@@ -39,7 +35,7 @@ namespace Imazen.Test.WebP
             }
 
             FileInfo finfo = new FileInfo(outFileName);
-            Assert.True(finfo.Exists);
+            Assert.IsTrue(finfo.Exists);
         }
     }
 }

--- a/src/Imazen.Test.Webp/TestSimpleEncoderDecoderRoundtrip.cs
+++ b/src/Imazen.Test.Webp/TestSimpleEncoderDecoderRoundtrip.cs
@@ -1,11 +1,12 @@
-﻿using System;
+﻿using Imazen.WebP;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using System.Drawing;
 using System.Drawing.Imaging;
-using Xunit;
-using Imazen.WebP;
 
 namespace Imazen.Test.Webp
 {
+    [TestClass]
     public class TestSimpleEncoderDecoderRoundtrip
     {
         private static readonly Random random = new Random();
@@ -53,8 +54,8 @@ namespace Imazen.Test.Webp
                 var webpBytes = outStream.ToArray();
                 var reloaded = decoder.DecodeFromBytes(webpBytes, webpBytes.LongLength);
 
-                Assert.Equal(gdiBitmap.Height, reloaded.Height);
-                Assert.Equal(gdiBitmap.Width, reloaded.Width);
+                Assert.AreEqual(gdiBitmap.Height, reloaded.Height);
+                Assert.AreEqual(gdiBitmap.Width, reloaded.Width);
 
                 for (var y = 0; y < reloaded.Height; y++)
                 {
@@ -62,13 +63,20 @@ namespace Imazen.Test.Webp
                     {
                         var expectedColor = gdiBitmap.GetPixel(x, y);
                         var actualColor   = reloaded.GetPixel(x, y);
-                        Assert.Equal(expectedColor, actualColor);
+                        if (expectedColor.A != 0)
+                        {
+                            Assert.AreEqual(expectedColor, actualColor);
+                        }
+                        else
+                        {
+                            Assert.AreEqual(Color.FromArgb(0, 0, 0, 0), actualColor);
+                        }
                     }
                 }
             }
         }
 
-        [Fact]
+        [TestMethod]
         public void TestRgb32()
         {
             Imazen.WebP.Extern.LoadLibrary.LoadWebPOrFail();
@@ -79,7 +87,7 @@ namespace Imazen.Test.Webp
             }
         }
 
-        [Fact]
+        [TestMethod]
         public void TestRgb24()
         {
             Imazen.WebP.Extern.LoadLibrary.LoadWebPOrFail();
@@ -90,7 +98,7 @@ namespace Imazen.Test.Webp
             }
         }
 
-        [Fact]
+        [TestMethod]
         public void TestAgb32()
         {
             Imazen.WebP.Extern.LoadLibrary.LoadWebPOrFail();

--- a/src/Imazen.Test.Webp/packages.config
+++ b/src/Imazen.Test.Webp/packages.config
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="xunit.runner.visualstudio" version="2.1.0" />
-</packages>

--- a/src/Imazen.WebP/Imazen.WebP.csproj
+++ b/src/Imazen.WebP/Imazen.WebP.csproj
@@ -1,114 +1,37 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{92F607A3-2F04-4536-8346-B6FEF8B774FF}</ProjectGuid>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Imazen.WebP</RootNamespace>
-    <AssemblyName>Imazen.WebP</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DocumentationFile>bin\Debug\Imazen.WebP.XML</DocumentationFile>
-    <Prefer32Bit>false</Prefer32Bit>
+    <DocumentationFile>bin\Debug\netstandard2.0\Imazen.WebP.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <DocumentationFile>bin\Release\Imazen.WebP.XML</DocumentationFile>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Prefer32Bit>false</Prefer32Bit>
+    <DocumentationFile>bin\Release\netstandard2.0\Imazen.WebP.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
-    <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\x64\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DocumentationFile>bin\Debug\Imazen.WebP.XML</DocumentationFile>
-    <DebugType>full</DebugType>
-    <PlatformTarget>x64</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
+    <DocumentationFile>bin\Debug\netstandard2.0\Imazen.WebP.XML</DocumentationFile>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DocumentationFile>bin\Release\Imazen.WebP.XML</DocumentationFile>
-    <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>x64</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
+    <DocumentationFile>bin\Release\netstandard2.0\Imazen.WebP.XML</DocumentationFile>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
-    <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\x86\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DocumentationFile>bin\Debug\Imazen.WebP.XML</DocumentationFile>
-    <DebugType>full</DebugType>
-    <PlatformTarget>x86</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
+    <DocumentationFile>bin\Debug\netstandard2.0\Imazen.WebP.XML</DocumentationFile>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <OutputPath>bin\x86\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DocumentationFile>bin\Release\Imazen.WebP.XML</DocumentationFile>
-    <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>x86</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
+    <DocumentationFile>bin\Release\netstandard2.0\Imazen.WebP.XML</DocumentationFile>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
+    <PackageReference Include="System.Drawing.Common" Version="9.0.4" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Extern\Extra.cs" />
-    <Compile Include="Extern\LoadLibrary.cs" />
-    <Compile Include="SimpleDecoder.cs" />
-    <Compile Include="Extern\Constants.cs" />
-    <Compile Include="Extern\Decode.cs" />
-    <Compile Include="Extern\DecodeInlines.cs" />
-    <Compile Include="Extern\Encode.cs" />
-    <Compile Include="Extern\EncodeInlines.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="SimpleEncoder.cs" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/src/Imazen.WebP/packages/repositories.config
+++ b/src/Imazen.WebP/packages/repositories.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<repositories>
-  <repository path="..\..\Imazen.Test.Webp\packages.config" />
-</repositories>


### PR DESCRIPTION
This PR migrate the libwebp-net project to .NET Standard 2.0 and the tests project to .NET 4.7.2/.NET 8.0. The PR also fixes a couple of minor issues with the tests.